### PR TITLE
Fix "Reset" button to clear the label

### DIFF
--- a/chronometer2/Cronometro.java
+++ b/chronometer2/Cronometro.java
@@ -81,6 +81,7 @@ class Cronometro{
           btReset.setText("Reset");  // when running, if you click btReset, it only stops the clock
         } else {
           // if the clock is stopped, then this button resets the chronometer
+          contagemTempo.setText(String.format("00:00:00"));
           tm.cancel();
           running = false;
 


### PR DESCRIPTION
Previous: "Reset" button should be pressed with "Iniciar" to clear the chronometer.
Now: When "Reset" button gets pressed it does what it should do.